### PR TITLE
greenlet 3.1.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "greenlet" %}
-{% set version = "3.0.1" %}
+{% set version = "3.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/greenlet-{{ version }}.tar.gz
-  sha256: 816bd9488a94cba78d93e1abb58000e8266fa9cc2aa9ccdd6eb0696acb24005b
+  sha256: 4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6193](https://anaconda.atlassian.net/browse/PKG-6193)
- [Upstream repository](https://github.com/python-greenlet/greenlet/tree/3.1.1)
- [Upstream changelog/diff](https://github.com/python-greenlet/greenlet/blob/3.1.1/CHANGES.rst)

### Explanation of changes:

- Update version
- Building for python 3.13


[PKG-6193]: https://anaconda.atlassian.net/browse/PKG-6193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ