### PR TITLE
greenlet 3.2.4 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,32 +1,33 @@
 {% set name = "greenlet" %}
-{% set version = "3.1.1" %}
+{% set version = "3.2.4" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/greenlet-{{ version }}.tar.gz
-  sha256: 4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d
 
 build:
   number: 0
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv --ignore-installed .
-  missing_dso_whitelist:  # [s390x]
-    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
   host:
     - pip
     - python
-    - setuptools
+    - setuptools >=40.8.0
     - wheel
   run:
     - python
 
+# Upstream tests were not added due to missing objgraph from main channel
 test:
   imports:
     - greenlet


### PR DESCRIPTION
greenlet 3.2.4 

**Destination channel:** default

### Links

- [PKG-9532]
- dev_url:        https://github.com/python-greenlet/greenlet/tree/3.2.4
- conda_forge:    https://github.com/conda-forge/greenlet-feedstock
- pypi:           https://pypi.org/project/greenlet/3.2.4
- pypi inspector: https://inspector.pypi.io/project/greenlet/3.2.4

### Explanation of changes:

- new version number


[PKG-9532]: https://anaconda.atlassian.net/browse/PKG-9532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ