### PR TITLE
yet another greenlet 3.2.4 build with pinned OSX SDK

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+cxx_compiler_version:    # [osx]
+  - 14                   # [osx]
+MACOSX_SDK_VERSION:      # [osx]
+  - 11.1                 # [osx]
+CONDA_BUILD_SYSROOT:     # [osx]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,6 @@ build:
 
 requirements:
   build:
-    - {{ stdlib("c") }}
-    - {{ compiler("c") }}
     - {{ compiler("cxx") }}
   host:
     - pip


### PR DESCRIPTION
greenlet 3.2.4 

**Destination channel:** default

### Links

- [PKG-9532]
- dev_url:        https://github.com/python-greenlet/greenlet/tree/3.2.4
- conda_forge:    https://github.com/conda-forge/greenlet-feedstock
- pypi:           https://pypi.org/project/greenlet/3.2.4
- pypi inspector: https://inspector.pypi.io/project/greenlet/3.2.4

### Explanation of changes:

- retrigger the build
- pin OSX SDK and Clang version

[PKG-9532]: https://anaconda.atlassian.net/browse/PKG-9532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ